### PR TITLE
Don't create a `NumberFormatter` every time we format a number

### DIFF
--- a/Example/Tests/NMBRTests.swift
+++ b/Example/Tests/NMBRTests.swift
@@ -144,3 +144,18 @@ final class NMBRFormatterCurrencyTests: XCTestCase {
         XCTAssertEqual("£100", formatter.format(100))
     }
 }
+
+final class NMBRFormatterPerformanceTests: XCTestCase {
+
+    func testPerformance() {
+        let formatter = NMBRFormatter()
+        formatter.currencyCode = "EUR"
+        formatter.locale = Locale(identifier: "es_ES")
+
+        measure {
+            for amount in 1..<10000 {
+                _ = formatter.format(Double(amount))
+            }
+        }
+    }
+}

--- a/Example/Tests/NMBRTests.swift
+++ b/Example/Tests/NMBRTests.swift
@@ -149,8 +149,6 @@ final class NMBRFormatterPerformanceTests: XCTestCase {
 
     func testPerformance() {
         let formatter = NMBRFormatter()
-        formatter.currencyCode = "EUR"
-        formatter.locale = Locale(identifier: "es_ES")
 
         measure {
             for amount in 1..<10000 {

--- a/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/55F582C0-E768-42D7-9C18-F32A4A8D84AB.plist
+++ b/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/55F582C0-E768-42D7-9C18-F32A4A8D84AB.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.909932</real>
+					<real>0.531000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/55F582C0-E768-42D7-9C18-F32A4A8D84AB.plist
+++ b/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/55F582C0-E768-42D7-9C18-F32A4A8D84AB.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>NMBRFormatterPerformanceTests</key>
+		<dict>
+			<key>testPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.909932</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/Info.plist
+++ b/Example/nmbr.xcodeproj/xcshareddata/xcbaselines/607FACE41AFB9204008FA782.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>55F582C0-E768-42D7-9C18-F32A4A8D84AB</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Pro</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>MacBookPro18,3</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPod9,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/nmbr/Classes/NMBRFormatter.swift
+++ b/nmbr/Classes/NMBRFormatter.swift
@@ -6,6 +6,10 @@ public enum NumberFormat {
 
 public final class NMBRFormatter {
 
+    private enum Constants {
+        static let initialLocaleValue: Locale = .autoupdatingCurrent
+    }
+
     private struct Scale: CustomStringConvertible {
         let min: Decimal
         let format: String
@@ -15,13 +19,28 @@ public final class NMBRFormatter {
         }
     }
 
-    public var precision: Int = 2
+    private let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Constants.initialLocaleValue
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
 
+    public var precision: Int = 2
     public var outputFormat: NumberFormat = .short
 
-    public var locale: Locale = Locale.autoupdatingCurrent
+    public var locale: Locale = Constants.initialLocaleValue {
+        didSet {
+            self.formatter.locale = self.locale
+        }
+    }
 
-    public var currencyCode: String? = nil
+    public var currencyCode: String? = nil {
+        didSet {
+            self.formatter.currencyCode = self.currencyCode
+            self.formatter.numberStyle = self.currencyCode != nil ? .currency : .decimal
+        }
+    }
 
     public init() {
     }
@@ -80,14 +99,11 @@ public final class NMBRFormatter {
     }
 
     private func outputString(value: Double, format: String) -> String {
-        let formatter = NumberFormatter()
-        formatter.currencyCode = self.currencyCode
-        formatter.numberStyle = self.currencyCode != nil ? .currency : .decimal
 
         let rounded = value.rounded(to: self.precision)
 
         //let numberPart = String(format: "%.\(self.precision)f", value)
-        let numberPart = formatter.string(from: NSNumber(value: rounded))!
+        let numberPart = self.formatter.string(from: NSNumber(value: rounded))!
             .trimTrailing(decimalSeparator: self.locale.decimalSeparator)
 
         let format = String.localizedStringWithFormat(format, value)


### PR DESCRIPTION
Improves performance by about 50%